### PR TITLE
fix: correct a bug in the `getDailyBalances()` function

### DIFF
--- a/contracts/BalanceTracker.sol
+++ b/contracts/BalanceTracker.sol
@@ -240,8 +240,12 @@ contract BalanceTracker is OwnableUpgradeable, IBalanceTracker, IERC20Hook, Vers
              * Therefore find the record with a day that is ahead of the `to` day
              * and set the `balance` variable to the value of that record
              */
-            while (_balanceRecords[account][--recordIndex].day > toDay) {}
-            balance = _balanceRecords[account][recordIndex + 1].value;
+            while (recordIndex > 0 && _balanceRecords[account][--recordIndex].day > toDay) {}
+            if (recordIndex == 0 && _balanceRecords[account][recordIndex].day > toDay) {
+                balance = _balanceRecords[account][recordIndex].value;
+            } else {
+                balance = _balanceRecords[account][recordIndex + 1].value;
+            }
             day = _balanceRecords[account][recordIndex].day;
         }
 

--- a/contracts/base/Versionable.sol
+++ b/contracts/base/Versionable.sol
@@ -16,6 +16,6 @@ abstract contract Versionable is IVersionable {
      * @inheritdoc IVersionable
      */
     function $__VERSION() external pure returns (Version memory) {
-        return Version(1, 0, 0);
+        return Version(1, 0, 1);
     }
 }

--- a/test/BalanceTracker.test.ts
+++ b/test/BalanceTracker.test.ts
@@ -283,7 +283,7 @@ describe("Contract 'BalanceTracker'", async () => {
   const EXPECTED_VERSION: Version = {
     major: 1,
     minor: 0,
-    patch: 0
+    patch: 1
   };
 
   let balanceTrackerFactory: ContractFactory;

--- a/test/BalanceTracker.test.ts
+++ b/test/BalanceTracker.test.ts
@@ -702,6 +702,14 @@ describe("Contract 'BalanceTracker'", async () => {
           const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
           await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
         });
+
+        it("The 'from' day equals the init day and the `to` day is before the first record day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+          const dayFrom: number = context.balanceTrackerInitDay;
+          const dayTo: number = tokenTransfers[0].executionDay - 2;
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
       });
 
       describe("There is a single balance records starting 2 days after the init day with gaps and", async () => {

--- a/test/BalanceTracker.test.ts
+++ b/test/BalanceTracker.test.ts
@@ -669,6 +669,14 @@ describe("Contract 'BalanceTracker'", async () => {
           await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
         });
 
+        it("The 'from' day is after the init day and the `to` day is at the first record day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 1);
+          const dayFrom: number = context.balanceTrackerInitDay + 1;
+          const dayTo: number = tokenTransfers[0].executionDay;
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+
         it("The 'from' day is after the init day and the `to` day is prior the last record day", async () => {
           const context: TestContext = await initTestContext();
           const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 1);

--- a/test/BalanceTracker.test.ts
+++ b/test/BalanceTracker.test.ts
@@ -627,13 +627,13 @@ describe("Contract 'BalanceTracker'", async () => {
           amount: BigNumber.from(123456789)
         };
         const transfer2: TokenTransfer = {
-          executionDay: firstTransferDay + 2,
+          executionDay: firstTransferDay + 3,
           addressFrom: user2.address,
           addressTo: user1.address,
           amount: BigNumber.from(987654321)
         };
         const transfer3: TokenTransfer = {
-          executionDay: firstTransferDay + 6,
+          executionDay: firstTransferDay + 7,
           addressFrom: user1.address,
           addressTo: user2.address,
           amount: BigNumber.from(987654320 / 2)
@@ -644,8 +644,16 @@ describe("Contract 'BalanceTracker'", async () => {
         return [transfer1, transfer2, transfer3].slice(0, numberOfTransfers);
       }
 
-      describe("There are several balance records starting from the init day with gaps and", async () => {
-        it("The 'from' day equals the init day and the `to` day is after the last record day", async () => {
+      describe("There are 3 balance records starting from the init day with gaps and", async () => {
+        it("The 'from' day equals the init day and the `to` day equals the 'from' day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 1);
+          const dayFrom: number = context.balanceTrackerInitDay;
+          const dayTo: number = (dayFrom);
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+
+        it("The 'from' day equals the init day and the `to` day is after the last record", async () => {
           const context: TestContext = await initTestContext();
           const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 1);
           const dayFrom: number = context.balanceTrackerInitDay;
@@ -653,121 +661,399 @@ describe("Contract 'BalanceTracker'", async () => {
           await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
         });
 
-        it("The 'from' day equals the init day and the `to` day is prior the last record day", async () => {
-          const context: TestContext = await initTestContext();
-          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 1);
-          const dayFrom: number = context.balanceTrackerInitDay;
-          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 2;
-          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
-        });
-
-        it("The 'from' day is after the init day and the `to` day after the last record day", async () => {
+        it("The 'from' day is after the init day and the `to` day is after the first record", async () => {
           const context: TestContext = await initTestContext();
           const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 1);
           const dayFrom: number = context.balanceTrackerInitDay + 1;
-          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
+          const dayTo: number = tokenTransfers[0].executionDay + 1;
           await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
         });
 
-        it("The 'from' day is after the init day and the `to` day is at the first record day", async () => {
-          const context: TestContext = await initTestContext();
-          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 1);
-          const dayFrom: number = context.balanceTrackerInitDay + 1;
-          const dayTo: number = tokenTransfers[0].executionDay;
-          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
-        });
-
-        it("The 'from' day is after the init day and the `to` day is prior the last record day", async () => {
+        it("The 'from' day is after the init day and the `to` day is before the last record", async () => {
           const context: TestContext = await initTestContext();
           const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 1);
           const dayFrom: number = context.balanceTrackerInitDay + 1;
           const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 2;
-          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
-        });
-
-        it("The 'from' day and the `to` day are both between records and prior the last record day", async () => {
-          const context: TestContext = await initTestContext();
-          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 1);
-          const dayFrom: number = tokenTransfers[tokenTransfers.length - 2].executionDay;
-          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 2;
-          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
-        });
-
-        it("The 'from' day and the `to` day are both after the last record day", async () => {
-          const context: TestContext = await initTestContext();
-          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 1);
-          const dayFrom: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
-          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 3;
           await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
         });
       });
 
-      describe("There are several balance records starting 2 days after the init day with gaps and", async () => {
-        it("The 'from' day equals the init day and the `to` day is after the last record day", async () => {
-          const context: TestContext = await initTestContext();
-          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
-          const dayFrom: number = context.balanceTrackerInitDay;
-          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
-          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+      describe("There are 3 balance records starting 2 days after the init day with gaps and", async () => {
+        describe("The 'from' day equals the init day and", async () => {
+          it("The `to` day equals the 'from' day", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = context.balanceTrackerInitDay;
+            const dayTo: number = (dayFrom);
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is before the first record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = context.balanceTrackerInitDay;
+            const dayTo: number = tokenTransfers[0].executionDay - 2;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day equals the first record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = context.balanceTrackerInitDay;
+            const dayTo: number = tokenTransfers[0].executionDay - 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is after the first record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = context.balanceTrackerInitDay;
+            const dayTo: number = tokenTransfers[0].executionDay + 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is before the last record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = context.balanceTrackerInitDay;
+            const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 2;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day equals the last record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = context.balanceTrackerInitDay;
+            const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is after the last record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = context.balanceTrackerInitDay;
+            const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
         });
 
-        it("The 'from' day equals the init day and the `to` day is before the first record day", async () => {
-          const context: TestContext = await initTestContext();
-          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
-          const dayFrom: number = context.balanceTrackerInitDay;
-          const dayTo: number = tokenTransfers[0].executionDay - 2;
-          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        describe("The 'from' day is before the first record", async () => {
+          it("The `to` day equals the 'from' day", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[0].executionDay - 2;
+            const dayTo: number = (dayFrom);
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day equals the first record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[0].executionDay - 2;
+            const dayTo: number = tokenTransfers[0].executionDay - 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is after the first record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[0].executionDay - 2;
+            const dayTo: number = tokenTransfers[0].executionDay + 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is before the last record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[0].executionDay - 2;
+            const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 2;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day equals the last record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[0].executionDay - 2;
+            const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is after the last record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[0].executionDay - 2;
+            const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+        });
+
+        describe("The 'from' day equals the first record", async () => {
+          it("The `to` day equals the 'from' day", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[0].executionDay - 1;
+            const dayTo: number = (dayFrom);
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is after the first record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[0].executionDay - 1;
+            const dayTo: number = tokenTransfers[0].executionDay + 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is before the last record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[0].executionDay - 1;
+            const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 2;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day equals the last record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[0].executionDay - 1;
+            const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is after the last record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[0].executionDay - 1;
+            const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+        });
+
+        describe("The 'from' day is after the first record", async () => {
+          it("The `to` day equals the 'from' day", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[0].executionDay + 1;
+            const dayTo: number = (dayFrom);
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is before the last record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[0].executionDay + 1;
+            const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 2;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day equals the last record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[0].executionDay + 1;
+            const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is after the last record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[0].executionDay + 1;
+            const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+        });
+
+        describe("The 'from' day is before the last record", async () => {
+          it("The `to` day equals the 'from' day", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 2;
+            const dayTo: number = (dayFrom);
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day equals the last record day", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 2;
+            const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is after the last record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 2;
+            const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+        });
+
+        describe("The 'from' day equals the last record", async () => {
+          it("The `to` day equals the 'from' day", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 1;
+            const dayTo: number = (dayFrom);
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is after the last record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 1;
+            const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+        });
+
+        describe("The 'from' day is after the last record", async () => {
+          it("The `to` day equals the 'from' day", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
+            const dayTo: number = (dayFrom);
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is after the last record and the 'from' day", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3);
+            const dayFrom: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
+            const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 3;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
         });
       });
 
-      describe("There is a single balance records starting 2 days after the init day with gaps and", async () => {
-        it("The 'from' day equals the init day and the `to` day is after the last record day", async () => {
-          const context: TestContext = await initTestContext();
-          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3, 1);
-          const dayFrom: number = context.balanceTrackerInitDay;
-          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
-          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+      describe("There is a single starting 2 days after the init day with gaps day and", async () => {
+        describe("The 'from' day equals the init day and", async () => {
+          it("The `to` day equals the 'from' day", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3, 1);
+            const dayFrom: number = context.balanceTrackerInitDay;
+            const dayTo: number = (dayFrom);
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is before the first record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3, 1);
+            const dayFrom: number = context.balanceTrackerInitDay;
+            const dayTo: number = tokenTransfers[0].executionDay - 2;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day equals the first record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3, 1);
+            const dayFrom: number = context.balanceTrackerInitDay;
+            const dayTo: number = tokenTransfers[0].executionDay - 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is after the first record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3, 1);
+            const dayFrom: number = context.balanceTrackerInitDay;
+            const dayTo: number = tokenTransfers[0].executionDay + 3;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
         });
 
-        it("The 'from' day equals the init day and the `to` day is prior the last record day", async () => {
-          const context: TestContext = await initTestContext();
-          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3, 1);
-          const dayFrom: number = context.balanceTrackerInitDay;
-          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 2;
-          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        describe("The 'from' day is before the first record", async () => {
+          it("The `to` day equals the 'from' day", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3, 1);
+            const dayFrom: number = tokenTransfers[0].executionDay - 2;
+            const dayTo: number = (dayFrom);
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day equals the first record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3, 1);
+            const dayFrom: number = tokenTransfers[0].executionDay - 2;
+            const dayTo: number = tokenTransfers[0].executionDay - 1;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is after the first record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3, 1);
+            const dayFrom: number = tokenTransfers[0].executionDay - 2;
+            const dayTo: number = tokenTransfers[0].executionDay + 3;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
         });
 
-        it("The 'from' day is after the init day and the `to` day after the last record day", async () => {
-          const context: TestContext = await initTestContext();
-          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3, 1);
-          const dayFrom: number = context.balanceTrackerInitDay + 1;
-          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
-          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        describe("The 'from' day equals the first record", async () => {
+          it("The `to` day equals the 'from' day", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3, 1);
+            const dayFrom: number = tokenTransfers[0].executionDay - 1;
+            const dayTo: number = (dayFrom);
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
+
+          it("The `to` day is after the first record", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3, 1);
+            const dayFrom: number = tokenTransfers[0].executionDay - 1;
+            const dayTo: number = tokenTransfers[0].executionDay + 3;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
         });
 
-        it("The 'from' day is after the init day and the `to` day is prior the last record day", async () => {
-          const context: TestContext = await initTestContext();
-          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3, 1);
-          const dayFrom: number = context.balanceTrackerInitDay + 1;
-          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 2;
-          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
-        });
+        describe("The 'from' day is after the first record", async () => {
+          it("The `to` day equals the 'from' day", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3, 1);
+            const dayFrom: number = tokenTransfers[0].executionDay + 3;
+            const dayTo: number = (dayFrom);
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
 
-        it("The 'from' day and the `to` day are both after the last record day", async () => {
-          const context: TestContext = await initTestContext();
-          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3, 1);
-          const dayFrom: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
-          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 3;
-          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          it("The `to` day is after the 'from' day", async () => {
+            const context: TestContext = await initTestContext();
+            const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context.balanceTrackerInitDay + 3, 1);
+            const dayFrom: number = tokenTransfers[0].executionDay + 3;
+            const dayTo: number = dayFrom + 3;
+            await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+          });
         });
       });
 
       describe("There are no balance records", async () => {
+        it("The 'from' day equals the init day and the `to` day equals the 'from' day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = [];
+          const dayFrom: number = context.balanceTrackerInitDay;
+          const dayTo: number = (dayFrom);
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+
         it("The 'from' day equals the init day and the `to` day is three days after the init day", async () => {
           const context: TestContext = await initTestContext();
           const tokenTransfers: TokenTransfer[] = [];
           const dayFrom: number = context.balanceTrackerInitDay;
           const dayTo: number = context.balanceTrackerInitDay + 3;
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+
+        it("The 'from' day is 3 days after the init day and the `to` day equals the 'from' day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = [];
+          const dayFrom: number = context.balanceTrackerInitDay + 3;
+          const dayTo: number = (dayFrom);
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+
+        it("The 'from' day is 3 days after the init day and the `to` day is 5 days after the init day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = [];
+          const dayFrom: number = context.balanceTrackerInitDay + 3;
+          const dayTo: number = context.balanceTrackerInitDay + 5;
           await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
         });
       });


### PR DESCRIPTION
## Main changes
1. A bug has been fixed fixed in the `getDailyBalances()` function. The bug was manifested in the fact that, if there was only one balance record for an account, a request for a daily balance in the interval before the specified record ended in panic with the code 0x11 (17 dec) due to an incorrect calculation of the record index. Now the logic is corrected.
2. More test cases have been added to cover all possible combinations of day ranges for a given set of balance records when querying daily balances.

## Versioning

The smart contracts version has been updated to `v1.0.1`.

## Test Coverage

<details>

<summary>Test coverage details</summary>

| File                              |      % Stmts |     % Branch |      % Funcs |     % Lines |
|-----------------------------------|-------------:|-------------:|-------------:|------------:|
| contracts/                        |       100.00 |        95.00 |       100.00 |      100.00 |
| ├─ BalanceTracker.sol             |       100.00 |        95.00 |       100.00 |      100.00 |
| contracts/base/                   |       100.00 |       100.00 |       100.00 |      100.00 |
| ├─ Versionable.sol                |       100.00 |       100.00 |       100.00 |      100.00 |
| contracts/harnesses/              |        65.63 |        37.50 |        58.82 |       65.91 |
| ├─ BalanceTrackerHarness.sol      |        52.63 |        33.33 |        40.00 |       55.56 |
| ├─ HarnessAdministrable.sol       |        84.62 |        50.00 |        85.71 |       82.35 |
| contracts/interfaces/             |       100.00 |       100.00 |       100.00 |      100.00 |
| ├─ IBalanceTracker.sol            |       100.00 |       100.00 |       100.00 |      100.00 |
| ├─ IERC20Hook.sol                 |       100.00 |       100.00 |       100.00 |      100.00 |
| ├─ IVersionable.sol               |       100.00 |       100.00 |       100.00 |      100.00 |
| contracts/mocks/                  |       100.00 |       100.00 |       100.00 |      100.00 |
| ├─ ERC20MockForBalanceTracker.sol |       100.00 |       100.00 |       100.00 |      100.00 |
| --------------------------------- | ------------ | ------------ | ------------ | ----------- |
| All files                         |        87.21 |        75.00 |        80.56 |       87.29 |
| --------------------------------- | ------------ | ------------ | ------------ | ----------- |

</details>
